### PR TITLE
Merge dev into release: auth guard and UI fixes

### DIFF
--- a/src/app/contentaccess/login/Login.js
+++ b/src/app/contentaccess/login/Login.js
@@ -19,7 +19,7 @@ angular
   .config(function ($stateProvider) {
     $stateProvider
       .state('login.form', {
-        url: '?{partnerId}&{redirect}',
+        url: '?{partnerId}&{redirect}&{returnTo}',
         views: {
           login: {
             templateUrl: 'contentaccess/login/form/form.html',

--- a/src/app/contentaccess/login/LoginController.js
+++ b/src/app/contentaccess/login/LoginController.js
@@ -82,7 +82,13 @@ angular.module('platform-ui.contentaccess.login').controller(
           .success(function (data, status, headers, config) {
             $cookies.credentialId = data['credentialId'] //Credential.partyId
             $cookies.secretKey = data['secretKey']
-            callProxy(data)
+          var returnTo = $location.search()['returnTo']
+          if (returnTo) {
+            // If returnTo is provided, navigate internally instead of proxy redirect
+            $location.url(returnTo)
+            return
+          }
+          callProxy(data)
             //$state.go("login.success"); // PW-147: YM: No more login confirmation page.
             //alert('Login successful: '+$cookies.secretKey);
           })

--- a/src/app/contentaccess/subscription/Subscription.js
+++ b/src/app/contentaccess/subscription/Subscription.js
@@ -64,7 +64,7 @@ angular
           },
         },
         resolve: {
-          authCheck: ['$cookies', '$stateParams', '$state', function($cookies, $stateParams, $state) {
+          authCheck: ['$cookies', '$stateParams', '$state', '$q', function($cookies, $stateParams, $state, $q) {
             var partnerId = $stateParams.partnerId;
             var isTair = partnerId && partnerId.toLowerCase() === 'tair';
             
@@ -79,13 +79,16 @@ angular
                 if ($stateParams.redirect) {
                   returnUrl += '&redirect=' + encodeURIComponent($stateParams.redirect);
                 }
-                return $state.go('login.form', {
+                $state.go('login.form', {
                   partnerId: partnerId,
                   redirect: $stateParams.redirect,
                   returnTo: returnUrl,
                 });
+                // Return rejected promise to prevent current state from loading
+                return $q.reject('Authentication required');
               }
             }
+            return $q.resolve();
           }]
         }
       })

--- a/src/app/contentaccess/subscription/Subscription.js
+++ b/src/app/contentaccess/subscription/Subscription.js
@@ -63,33 +63,5 @@ angular
               'contentaccess/subscription/individual/individual.html',
           },
         },
-        resolve: {
-          authCheck: ['$cookies', '$stateParams', '$state', '$q', function($cookies, $stateParams, $state, $q) {
-            var partnerId = $stateParams.partnerId;
-            var isTair = partnerId && partnerId.toLowerCase() === 'tair';
-            
-            // Only require login for TAIR partner
-            if (isTair) {
-              var hasCredential = !!$cookies.credentialId;
-              var hasOrcid = !!$stateParams.orcid_id;
-              
-              if (!hasCredential && !hasOrcid) {
-                // Not logged in - redirect to login
-                var returnUrl = '/contentaccess/subscription/individual?partnerId=' + partnerId;
-                if ($stateParams.redirect) {
-                  returnUrl += '&redirect=' + encodeURIComponent($stateParams.redirect);
-                }
-                $state.go('login.form', {
-                  partnerId: partnerId,
-                  redirect: $stateParams.redirect,
-                  returnTo: returnUrl,
-                });
-                // Return rejected promise to prevent current state from loading
-                return $q.reject('Authentication required');
-              }
-            }
-            return $q.resolve();
-          }]
-        }
       })
   })

--- a/src/app/contentaccess/subscription/individual/Individual.js
+++ b/src/app/contentaccess/subscription/individual/Individual.js
@@ -55,40 +55,6 @@ angular
           },
         },
       },
-      resolve: {
-        authCheck: [
-          '$cookies',
-          '$stateParams',
-          '$state',
-          function ($cookies, $stateParams, $state) {
-            var partnerId = $stateParams.partnerId
-            var isTair = partnerId && partnerId.toLowerCase() === 'tair'
-            var hasOrcid = !!$stateParams.orcid_id
-            var hasCredential = !!$cookies.credentialId
-
-            if (!isTair) {
-              return
-            }
-
-            if (hasCredential || hasOrcid) {
-              return
-            }
-
-            var returnUrl =
-              '/contentaccess/subscription/individual?partnerId=' + partnerId
-            if ($stateParams.redirect) {
-              returnUrl +=
-                '&redirect=' + encodeURIComponent($stateParams.redirect)
-            }
-
-            return $state.go('login.form', {
-              partnerId: partnerId,
-              redirect: $stateParams.redirect,
-              returnTo: returnUrl,
-            })
-          },
-        ],
-      },
     })
       
       .state('subscription.individual.pay', {

--- a/src/app/contentaccess/subscription/individual/Individual.js
+++ b/src/app/contentaccess/subscription/individual/Individual.js
@@ -55,6 +55,40 @@ angular
           },
         },
       },
+      resolve: {
+        authCheck: [
+          '$cookies',
+          '$stateParams',
+          '$state',
+          function ($cookies, $stateParams, $state) {
+            var partnerId = $stateParams.partnerId
+            var isTair = partnerId && partnerId.toLowerCase() === 'tair'
+            var hasOrcid = !!$stateParams.orcid_id
+            var hasCredential = !!$cookies.credentialId
+
+            if (!isTair) {
+              return
+            }
+
+            if (hasCredential || hasOrcid) {
+              return
+            }
+
+            var returnUrl =
+              '/contentaccess/subscription/individual?partnerId=' + partnerId
+            if ($stateParams.redirect) {
+              returnUrl +=
+                '&redirect=' + encodeURIComponent($stateParams.redirect)
+            }
+
+            return $state.go('login.form', {
+              partnerId: partnerId,
+              redirect: $stateParams.redirect,
+              returnTo: returnUrl,
+            })
+          },
+        ],
+      },
     })
       
       .state('subscription.individual.pay', {

--- a/src/app/contentaccess/subscription/individual/IndividualController.js
+++ b/src/app/contentaccess/subscription/individual/IndividualController.js
@@ -261,7 +261,6 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
         $scope.selectedSubscription = IndividualModel.selectedSubscription
         $scope.selectedSubscriptionBucket = IndividualModel.selectedSubscriptionBucket
         $scope.loading = false
-        console.log('IndividualController init ', $state.params)
         $scope.orcid_id = $state.params.orcid_id
         // Set credentialId from cookie for logged-in users
         if ($cookies.credentialId) {
@@ -271,7 +270,6 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
         // Set the currentTab based on partnerId
         var partnerId = $state.params.partnerId;
         if (partnerId && partnerId.toLowerCase() === 'tair') {
-          console.log('partnerId is tair')
           $state.go('subscription.individual.bucket', {
             partnerId: partnerId,
             redirect: $state.params.redirect,

--- a/src/app/contentaccess/subscription/individual/IndividualController.js
+++ b/src/app/contentaccess/subscription/individual/IndividualController.js
@@ -13,10 +13,11 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
     '$rootScope',
     '$state',
     '$location',
+    '$cookies',
     'IndividualModel',
 
     /* Controller Definition */
-    function ($http, $scope, $rootScope, $state, $location, IndividualModel) {
+    function ($http, $scope, $rootScope, $state, $location, $cookies, IndividualModel) {
       init()
 
       $scope.next = function (nextTab) {
@@ -223,7 +224,8 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
                   other: $scope.formdata.other, //PW-248
                   redirect: $scope.redirect,
                   domain: $scope.domain,
-                  orcid_id: $scope.orcid_id || ""
+                  orcid_id: $scope.orcid_id || "",
+                  credentialId: $scope.credentialId || ""
                 },
                 method: 'POST',
                 timeout: 30000
@@ -261,6 +263,10 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
         $scope.loading = false
         console.log('IndividualController init ', $state.params)
         $scope.orcid_id = $state.params.orcid_id
+        // Set credentialId from cookie for logged-in users
+        if ($cookies.credentialId) {
+          $scope.credentialId = $cookies.credentialId
+        }
         
         // Set the currentTab based on partnerId
         var partnerId = $state.params.partnerId;

--- a/src/app/contentaccess/subscription/individual/IndividualController.js
+++ b/src/app/contentaccess/subscription/individual/IndividualController.js
@@ -267,9 +267,24 @@ angular.module('platform-ui.contentaccess.subscription.individual').controller(
           $scope.credentialId = $cookies.credentialId
         }
         
-        // Set the currentTab based on partnerId
+        // Require login for TAIR partner
         var partnerId = $state.params.partnerId;
-        if (partnerId && partnerId.toLowerCase() === 'tair') {
+        var isTair = partnerId && partnerId.toLowerCase() === 'tair';
+        if (isTair && !$cookies.credentialId && !$state.params.orcid_id) {
+          var returnUrl = '/contentaccess/subscription/individual?partnerId=' + partnerId;
+          if ($state.params.redirect) {
+            returnUrl += '&redirect=' + encodeURIComponent($state.params.redirect);
+          }
+          $state.go('login.form', {
+            partnerId: partnerId,
+            redirect: $state.params.redirect,
+            returnTo: returnUrl,
+          });
+          return;
+        }
+
+        // Set the currentTab based on partnerId
+        if (isTair) {
           $state.go('subscription.individual.bucket', {
             partnerId: partnerId,
             redirect: $state.params.redirect,

--- a/src/app/contentaccess/subscription/individual/bucket/BucketController.js
+++ b/src/app/contentaccess/subscription/individual/bucket/BucketController.js
@@ -10,11 +10,12 @@ angular
 		'$scope',
 		'$cookies',
 		'$rootScope',
+		'$state',
 		'$stateParams',
 		'BucketModel',
 
 		/* Controller Definition */
-		function ($http, $scope, $cookies, $rootScope, $stateParams, BucketModel) {
+		function ($http, $scope, $cookies, $rootScope, $state, $stateParams, BucketModel) {
 			init()
 
 			$scope.validate = function () {
@@ -50,20 +51,28 @@ angular
 
 			function init() {
 				var debugMsg = ''
-				// $scope.subscriptions = BucketModel.subscriptions
-				if ($scope.partnerId == null) {
-					console.log('partnerId is null')
-				}
-				if ($stateParams.orcid_id == null) {
-					console.log('orcid_id is null')
-					if ($cookies.credentialId != null) {
-						$scope.credentialId = $cookies.credentialId
-						console.log($scope.credentialId)
-					} else {
-						console.log('credentialId is null')
+				var partnerId = $stateParams.partnerId;
+				var isTair = partnerId && partnerId.toLowerCase() === 'tair';
+
+				// Require login for TAIR partner
+				if (isTair && !$cookies.credentialId && !$stateParams.orcid_id) {
+					var returnUrl = '/contentaccess/subscription/individual?partnerId=' + partnerId;
+					if ($stateParams.redirect) {
+						returnUrl += '&redirect=' + encodeURIComponent($stateParams.redirect);
 					}
+					$state.go('login.form', {
+						partnerId: partnerId,
+						redirect: $stateParams.redirect,
+						returnTo: returnUrl,
+					});
+					return;
 				}
 
+				if ($stateParams.orcid_id == null) {
+					if ($cookies.credentialId != null) {
+						$scope.credentialId = $cookies.credentialId
+					}
+				}
 
 				//rewrite the default values with correct actual values
 				$http({

--- a/src/app/contentaccess/subscription/landing/LandingController.js
+++ b/src/app/contentaccess/subscription/landing/LandingController.js
@@ -27,7 +27,7 @@ angular.module('platform-ui.contentaccess.subscription.landing').controller(
         if ($scope.license == 'individual') {
           var isTair = $scope.partnerId && $scope.partnerId.toLowerCase() === 'tair';
           // Require login for TAIR individual subscriptions
-          if (isTair && !$cookies.credentialId) {
+          if (isTair && !$cookies.credentialId && !$state.params.orcid_id) {
             var returnUrl = '/contentaccess/subscription/individual?partnerId=' + $scope.partnerId;
             if ($scope.redirect) {
               returnUrl += '&redirect=' + encodeURIComponent($scope.redirect);
@@ -39,7 +39,7 @@ angular.module('platform-ui.contentaccess.subscription.landing').controller(
             });
             return;
           }
-          if (!isTair) {
+          if ($scope.partnerId && $scope.partnerId.toLowerCase() != 'tair') {
             $state.go('subscription.individual.term', {
               partnerId: $scope.partnerId,
               redirect: $scope.redirect,

--- a/src/app/contentaccess/subscription/landing/LandingController.js
+++ b/src/app/contentaccess/subscription/landing/LandingController.js
@@ -12,11 +12,12 @@ angular.module('platform-ui.contentaccess.subscription.landing').controller(
     '$scope',
     '$location',
     '$state',
+    '$cookies',
     'Title',
     'LandingModel',
 
     /* Controller Definition */
-    function ($http, $scope, $location, $state, Title, LandingModel) {
+    function ($http, $scope, $location, $state, $cookies, Title, LandingModel) {
       $scope.next = function () {
         if ($scope.license == 'def') {
           alert('Please select a license type')
@@ -24,7 +25,21 @@ angular.module('platform-ui.contentaccess.subscription.landing').controller(
         }
         //$scope.switchTab($scope.license);
         if ($scope.license == 'individual') {
-          if ($scope.partnerId && $scope.partnerId.toLowerCase() != 'tair') {
+          var isTair = $scope.partnerId && $scope.partnerId.toLowerCase() === 'tair';
+          // Require login for TAIR individual subscriptions
+          if (isTair && !$cookies.credentialId) {
+            var returnUrl = '/contentaccess/subscription/individual?partnerId=' + $scope.partnerId;
+            if ($scope.redirect) {
+              returnUrl += '&redirect=' + encodeURIComponent($scope.redirect);
+            }
+            $state.go('login.form', {
+              partnerId: $scope.partnerId,
+              redirect: $scope.redirect,
+              returnTo: returnUrl,
+            });
+            return;
+          }
+          if (!isTair) {
             $state.go('subscription.individual.term', {
               partnerId: $scope.partnerId,
               redirect: $scope.redirect,


### PR DESCRIPTION
## Summary
- Add login guard for unauthenticated TAIR users on individual subscription page (TAIR3-786)
- Fix Buy Usage Units button not navigating (changed `<button>` to `<a>`)
- Auth check in LandingController, IndividualController, and BucketController

## Test plan
- [ ] Verify unauthenticated users are redirected to login when accessing individual subscription
- [ ] Verify "Buy Usage Units" button works from profile page
- [ ] Verify purchase flow works end-to-end with discount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new login-gating and internal post-login navigation for TAIR subscription flows, which can affect user routing and purchase entry points if query/state params are mishandled. Changes are localized to AngularJS controllers/routes but touch authentication-adjacent behavior (cookie checks and redirects).
> 
> **Overview**
> Adds a TAIR-specific auth guard to the individual subscription flow: unauthenticated users (no `credentialId` cookie and no `orcid_id`) are redirected to `login.form` from `LandingController`, `IndividualController`, and `BucketController`, with a computed `returnTo` URL to resume the flow after login.
> 
> Extends the login route and controller to accept `returnTo` and, on successful login, navigate internally via `$location.url(returnTo)` instead of always proxy-redirecting back to the partner site.
> 
> Simplifies `subscription.individual` routing by removing the resolve-based auto-redirect logic, and updates bucket payment payloads to include `credentialId` when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8cc32b34d1b080bb614d6603bdd324288712b4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->